### PR TITLE
Test updates: Fix translation errors & document unfixable errors

### DIFF
--- a/tests/cql/CqlAggregateTest.xml
+++ b/tests/cql/CqlAggregateTest.xml
@@ -3,14 +3,11 @@
   name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
 	<group name="AggregateTests">
 		<test name="FactorialOfFive">
-			<expression>define FactorialOfFive:
-  ({ 1, 2, 3, 4, 5 }) Num
-    aggregate Result starting 1: Result * Num</expression>
+			<expression>({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num</expression>
 			<output>120</output>
 		</test>
     <test name="RolledOutIntervals">
-      <expression>define "RolledOutIntervals":
-  MedicationRequestIntervals M
+      <expression>MedicationRequestIntervals M
     aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
       M X
         let S: Max({ end of Last(R) + 1 day, start of X }),
@@ -18,6 +15,7 @@
         return Interval[S, E]
     })</expression>
       <output>TODO</output>
+      <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
     </test>
   </group>
 </tests>

--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -237,7 +237,7 @@
 		</test>
 		<test name="Log1Base1">
 			<expression>Log(1, 1)</expression>
-			<output>0.0</output>
+			<output>null</output>
 		</test>
 		<test name="Log1Base2">
 			<expression>Log(1, 2)</expression>
@@ -397,8 +397,8 @@
 			<output>0.5</output>
 		</test>
 		<test name="ModuloQuantity">
-			<expression>3.5 'gm' mod 3 'gm'</expression>
-			<output>0.5 'gm'</output>
+			<expression>3.5 'cm' mod 3 'cm'</expression>
+			<output>0.5 'cm'</output>
 		</test>
 	</group>
 	<group name="Multiply">
@@ -527,7 +527,7 @@
 		</test>
 		<test name="PredecessorOfJan12000">
 			<expression>predecessor of DateTime(2000,1,1)</expression>
-			<output>@1999-12-31</output>
+			<output>@1999-12-31T</output>
 		</test>
 		<test name="PredecessorOfNoon">
 			<expression>predecessor of @T12:00:00.000</expression>
@@ -699,7 +699,7 @@
 		</test>
 		<test name="SuccessorOfJan12000">
 			<expression>successor of DateTime(2000,1,1)</expression>
-			<output>@2000-01-02</output>
+			<output>@2000-01-02T</output>
 		</test>
 		<test name="SuccessorOfNoon">
 			<expression>successor of @T12:00:00.000</expression>
@@ -826,8 +826,8 @@
 			<output>2.0</output>
 		</test>
 		<test name="TruncatedDivide10d1ByNeg3D1Quantity">
-			<expression>10.1 'gm' div -3.1 'gm'</expression>
-			<output>-3.0 'gm'</output>
+			<expression>10.1 'cm' div -3.1 'cm'</expression>
+			<output>-3.0 'cm'</output>
 		</test>
 	</group>
 </tests>

--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -274,7 +274,6 @@
 			<output>@T10:30:00.000</output>
 		</test>
 	</group>
-	</group>
 	<group name="Ln">
 		<test name="LnNull">
 			<expression>Ln(null)</expression>

--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -316,7 +316,7 @@
 		</test>
 		<test name="DecimalMinValue">
 			<expression>minimum Decimal</expression>
-			<output>-9999999999999999999999999999.99999999</output>
+			<output>-99999999999999999999.99999999</output>
 		</test>
 		<!-- OBSOLETE: define QuantityMinValue: minimum Quantity -->
 		<test name="DateTimeMinValue">
@@ -343,7 +343,7 @@
 		</test>
 		<test name="DecimalMaxValue">
 			<expression>maximum Decimal</expression>
-			<output>9999999999999999999999999999.99999999</output>
+			<output>99999999999999999999.99999999</output>
 		</test>
 		<!-- OBSOLETE: define QuantityMaxValue: maximum Quantity -->
 		<test name="DateTimeMaxValue">

--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -25,7 +25,7 @@
 			<output>false</output>
 		</test>
 		<test name="SimpleEqNullNull">
-			<expression>null = null</expression>
+			<expression>null as String = null</expression>
 			<output>null</output>
 		</test>
 		<test name="SimpleEqTrueNull">
@@ -576,7 +576,7 @@
 			<output>false</output>
 		</test>
 		<test name="EquivNullNull">
-			<expression>null ~ null</expression>
+			<expression>null as String ~ null</expression>
 			<output>true</output>
 		</test>
 		<test name="EquivTrueNull">
@@ -679,7 +679,7 @@
 			<output>true</output>
 		</test>
 		<test name="SimpleNotEqNullNull">
-			<expression>null != null</expression>
+			<expression>null as String != null</expression>
 			<output>null</output>
 		</test>
 		<test name="SimpleNotEqTrueNull">

--- a/tests/cql/CqlDateTimeOperatorsTest.xml
+++ b/tests/cql/CqlDateTimeOperatorsTest.xml
@@ -594,7 +594,7 @@
 		<test name="DateTimeDurationBetweenUncertainSubtract">
 			<expression>(days between DateTime(2014, 1, 15) and DateTime(2014, 2))
 				- (months between DateTime(2005) and DateTime(2006, 5))</expression>
-			<output>Interval[ 12, 28 ]</output>
+			<output>Interval[ 0, 40 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;

--- a/tests/cql/CqlDateTimeOperatorsTest.xml
+++ b/tests/cql/CqlDateTimeOperatorsTest.xml
@@ -4,7 +4,7 @@
 	<group name="Add">
 		<test name="DateTimeAdd5Years">
 			<expression>DateTime(2005, 10, 10) + 5 years</expression>
-			<output>@2010-10-10</output>
+			<output>@2010-10-10T</output>
 		</test>
 		<test name="DateTimeAddInvalidYears">
 			<expression invalid="true">DateTime(2005, 10, 10) + 8000 years</expression>
@@ -12,19 +12,19 @@
 		</test>
 		<test name="DateTimeAdd5Months">
 			<expression>DateTime(2005, 5, 10) + 5 months</expression>
-			<output>@2005-10-10</output>
+			<output>@2005-10-10T</output>
 		</test>
 		<test name="DateTimeAddMonthsOverflow">
 			<expression>DateTime(2005, 5, 10) + 10 months</expression>
-			<output>@2006-03-10</output>
+			<output>@2006-03-10T</output>
 		</test>
 		<test name="DateTimeAdd5Days">
 			<expression>DateTime(2005, 5, 10) + 5 days</expression>
-			<output>@2005-05-15</output>
+			<output>@2005-05-15T</output>
 		</test>
 		<test name="DateTimeAddDaysOverflow">
 			<expression>DateTime(2016, 6, 10) + 21 days</expression>
-			<output>@2016-07-01</output>
+			<output>@2016-07-01T</output>
 		</test>
 		<test name="DateTimeAdd5Hours">
 			<expression>DateTime(2005, 5, 10, 5) + 5 hours</expression>
@@ -60,19 +60,19 @@
 		</test>
 		<test name="DateTimeAddLeapYear">
 			<expression>DateTime(2012, 2, 29) + 1 year</expression>
-			<output>@2013-02-28</output>
+			<output>@2013-02-28T</output>
 		</test>
 		<test name="DateTimeAdd2YearsByMonths">
 			<expression>DateTime(2014) + 24 months</expression>
-			<output>@2016</output>
+			<output>@2016T</output>
 		</test>
 		<test name="DateTimeAdd2YearsByDays">
 			<expression>DateTime(2014) + 730 days</expression>
-			<output>@2016</output>
+			<output>@2016T</output>
 		</test>
 		<test name="DateTimeAdd2YearsByDaysRem5Days">
 			<expression>DateTime(2014) + 735 days</expression>
-			<output>@2016</output>
+			<output>@2016T</output>
 		</test>
 		<test name="TimeAdd5Hours">
 			<expression>@T15:59:59.999 + 5 hours</expression>
@@ -316,15 +316,15 @@
 	<group name="DateTime">
 		<test name="DateTimeYear">
 			<expression>DateTime(2003)</expression>
-			<output>@2003</output>
+			<output>@2003T</output>
 		</test>
 		<test name="DateTimeMonth">
 			<expression>DateTime(2003, 10)</expression>
-			<output>@2003-10</output>
+			<output>@2003-10T</output>
 		</test>
 		<test name="DateTimeDay">
 			<expression>DateTime(2003, 10, 29)</expression>
-			<output>@2003-10-29</output>
+			<output>@2003-10-29T</output>
 		</test>
 		<test name="DateTimeHour">
 			<expression>DateTime(2003, 10, 29, 20)</expression>
@@ -441,7 +441,7 @@
 		</test>
 		<test name="DateTimeDifferenceWeeks3">
 			<expression>difference in weeks between @2012-03-10T22:05:09 and @2012-03-24T07:19:33</expression>
-			<output>1</output>
+			<output>2</output>
 		</test>
 		<test name="DateTimeDifferenceNegative">
 			<expression>difference in years between DateTime(2016) and DateTime(1998)</expression>
@@ -471,51 +471,51 @@
 	<group name="From Github issue #29">
 		<test name="DateTimeA">
 			<expression>@2017-03-12T01:00:00-07:00</expression>
-			<output>@2017-03-12T01:00:00</output>
+			<output>@2017-03-12T01:00:00-07:00</output>
 		</test>
 		<test name="DateTimeAA">
 			<expression>DateTime(2017, 3, 12, 1, 0, 0, 0, -7.0)</expression>
-			<output>@2017-03-12T01:00:00.000</output>
+			<output>@2017-03-12T01:00:00.000-07:00</output>
 		</test>
 		<test name="DateTimeB">
 			<expression>@2017-03-12T03:00:00-06:00</expression>
-			<output>@2017-03-12T03:00:00</output>
+			<output>@2017-03-12T03:00:00-06:00</output>
 		</test>
 		<test name="DateTimeBB">
 			<expression>DateTime(2017, 3, 12, 3, 0, 0, 0, -6.0)</expression>
-			<output>@2017-03-12T03:00:00.000</output>
+			<output>@2017-03-12T03:00:00.000-06:00</output>
 		</test>
 		<test name="DateTimeC">
 			<expression>@2017-11-05T01:30:00-06:00</expression>
-			<output>@2017-11-05T01:30:00</output>
+			<output>@2017-11-05T01:30:00-06:00</output>
 		</test>
 		<test name="DateTimeCC">
 			<expression>DateTime(2017, 11, 5, 1, 30, 0, 0, -6.0)</expression>
-			<output>@2017-11-05T01:30:00.000</output>
+			<output>@2017-11-05T01:30:00.000-06:00</output>
 		</test>
 		<test name="DateTimeD">
 			<expression>@2017-11-05T01:15:00-07:00</expression>
-			<output>@2017-11-05T01:15:00</output>
+			<output>@2017-11-05T01:15:00-07:00</output>
 		</test>
 		<test name="DateTimeDD">
 			<expression>DateTime(2017, 11, 5, 1, 15, 0, 0, -7.0)</expression>
-			<output>@2017-11-05T01:15:00.000</output>
+			<output>@2017-11-05T01:15:00.000-07:00</output>
 		</test>
 		<test name="DateTimeE">
 			<expression>@2017-03-12T00:00:00-07:00</expression>
-			<output>@2017-03-12T00:00:00</output>
+			<output>@2017-03-12T00:00:00-07:00</output>
 		</test>
 		<test name="DateTimeEE">
 			<expression>DateTime(2017, 3, 12, 0, 0, 0, 0, -7.0)</expression>
-			<output>@2017-03-12T00:00:00.000</output>
+			<output>@2017-03-12T00:00:00.000-07:00</output>
 		</test>
 		<test name="DateTimeF">
 			<expression>@2017-03-13T00:00:00-06:00</expression>
-			<output>@2017-03-13T00:00:00</output>
+			<output>@2017-03-13T00:00:00-06:00</output>
 		</test>
 		<test name="DateTimeFF">
 			<expression>DateTime(2017, 3, 13, 0, 0, 0, 0, -6.0)</expression>
-			<output>@2017-03-13T00:00:00.000</output>
+			<output>@2017-03-13T00:00:00.000-06:00</output>
 		</test>
 		<test name="DifferenceInHoursA">
 			<expression>difference in hours between @2017-03-12T01:00:00-07:00 and @2017-03-12T03:00:00-06:00</expression>
@@ -546,7 +546,11 @@
 	<group name="Duration">
 		<test name="DateTimeDurationBetweenYear">
 			<expression>years between DateTime(2005) and DateTime(2010)</expression>
-			<output>5</output>
+			<output>Interval[ 4, 5 ]</output>
+			<!-- TODO: How to handle the fact the question is resulting in an
+			undertainty interval and that CQL/ELM seem to provide no direct way of
+			selecting the same value, conceptually an implementation internal;
+			currently Equivalent() results in null from comparing with an Interval. -->
 		</test>
 		<test name="DateTimeDurationBetweenYearOffset">
 			<expression>years between DateTime(2005, 5) and DateTime(2010, 4)</expression>
@@ -564,7 +568,7 @@
 	<group name="Uncertainty tests">
 		<test name="DateTimeDurationBetweenUncertainInterval">
 			<expression>days between DateTime(2014, 1, 15) and DateTime(2014, 2)</expression>
-			<output>Interval[ 17, 44 ]</output>
+			<output>Interval[ 16, 44 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;
@@ -572,7 +576,7 @@
 		</test>
 		<test name="DateTimeDurationBetweenUncertainInterval2">
 			<expression>months between DateTime(2005) and DateTime(2006, 5)</expression>
-			<output>Interval[ 5, 16 ]</output>
+			<output>Interval[ 4, 16 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;
@@ -581,7 +585,7 @@
 		<test name="DateTimeDurationBetweenUncertainAdd">
 			<expression>(days between DateTime(2014, 1, 15) and DateTime(2014, 2))
 				+ (days between DateTime(2014, 1, 15) and DateTime(2014, 2))</expression>
-			<output>Interval[ 34, 88 ]</output>
+			<output>Interval[ 32, 88 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;
@@ -599,7 +603,7 @@
 		<test name="DateTimeDurationBetweenUncertainMultiply">
 			<expression>(days between DateTime(2014, 1, 15) and DateTime(2014, 2))
 				* (days between DateTime(2014, 1, 15) and DateTime(2014, 2))</expression>
-			<output>Interval[ 289, 1936 ]</output>
+			<output>Interval[ 256, 1936 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;
@@ -1123,7 +1127,7 @@
 	<group name="Subtract">
 		<test name="DateTimeSubtract5Years">
 			<expression>DateTime(2005, 10, 10) - 5 years</expression>
-			<output>@2000-10-10</output>
+			<output>@2000-10-10T</output>
 		</test>
 		<test name="DateTimeSubtractInvalidYears">
 			<expression invalid="true">DateTime(2005, 10, 10) - 2005 years</expression>
@@ -1131,19 +1135,19 @@
 		</test>
 		<test name="DateTimeSubtract5Months">
 			<expression>DateTime(2005, 6, 10) - 5 months</expression>
-			<output>@2005-01-10</output>
+			<output>@2005-01-10T</output>
 		</test>
 		<test name="DateTimeSubtractMonthsUnderflow">
 			<expression>DateTime(2005, 5, 10) - 6 months</expression>
-			<output>@2004-11-10</output>
+			<output>@2004-11-10T</output>
 		</test>
 		<test name="DateTimeSubtract5Days">
 			<expression>DateTime(2005, 5, 10) - 5 days</expression>
-			<output>@2005-05-05</output>
+			<output>@2005-05-05T</output>
 		</test>
 		<test name="DateTimeSubtractDaysUnderflow">
 			<expression>DateTime(2016, 6, 10) - 11 days</expression>
-			<output>@2016-05-30</output>
+			<output>@2016-05-30T</output>
 		</test>
 		<test name="DateTimeSubtract5Hours">
 			<expression>DateTime(2005, 5, 10, 10) - 5 hours</expression>
@@ -1179,11 +1183,11 @@
 		</test>
 		<test name="DateTimeSubtract2YearsAsMonths">
 			<expression>DateTime(2014) - 24 months</expression>
-			<output>@2012</output>
+			<output>@2012T</output>
 		</test>
 		<test name="DateTimeSubtract2YearsAsMonthsRem1">
 			<expression>DateTime(2014) - 25 months</expression>
-			<output>@2011</output>
+			<output>@2012T</output>
 		</test>
 		<test name="TimeSubtract5Hours">
 			<expression>@T15:59:59.999 - 5 hours</expression>

--- a/tests/cql/CqlDateTimeOperatorsTest.xml
+++ b/tests/cql/CqlDateTimeOperatorsTest.xml
@@ -379,6 +379,7 @@
 		<test name="DateTimeComponentFromTimezone">
 			<expression>timezone from DateTime(2003, 10, 29, 20, 50, 33, 955, 1)</expression>
 			<output>1.00</output>
+			<!-- Translation Error: Timezone keyword is only valid in 1.3 or lower -->
 		</test>
 		<test name="DateTimeComponentFromDate">
 			<expression>date from DateTime(2003, 10, 29, 20, 50, 33, 955, 1)</expression>
@@ -667,6 +668,7 @@
 		<test name="TimeDurationBetweenHourDiffPrecision">
 			<expression>hours between @T06Z and @T07:00:00Z</expression>
 			<output>1</output>
+			<!-- Translation Error: Syntax error at Z -->
 		</test>
 		<test name="TimeDurationBetweenMinute">
 			<expression>minutes between @T23:20:16.555 and @T23:25:15.555</expression>

--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -926,7 +926,7 @@
 	</group>
 	<group name="OnOrAfter">
 		<test name="TestOnOrAfterNull">
-			<expression>Interval[@2012-12-01, @2013-12-01] on or after null</expression>
+			<expression>Interval[@2012-12-01, @2013-12-01] on or after (null as Interval&lt;Date&gt;)</expression>
 			<output>null</output>
 		</test>
 		<test name="TestOnOrAfterDateTrue">
@@ -960,7 +960,7 @@
 	</group>
 	<group name="OnOrBefore">
 		<test name="TestOnOrBeforeNull">
-			<expression>Interval[@2012-12-01, @2013-12-01] on or before null</expression>
+			<expression>Interval[@2012-12-01, @2013-12-01] on or before (null as Interval&lt;Date&gt;)</expression>
 			<output>null</output>
 		</test>
 		<test name="TestOnOrBeforeDateTrue">

--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -264,11 +264,11 @@
 		</test>
 		<test name="ExpandInterval">
 			<expression>expand Interval[1, 10]</expression>
-			<output>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }</output>
+			<output>{ Interval[1, 1], Interval[2, 2], Interval[3, 3], Interval[4, 4], Interval[5, 5], Interval[6, 6], Interval[7, 7], Interval[8, 8], Interval[9, 9], Interval[10, 10] }</output>
 		</test>
 		<test name="ExpandIntervalPer2">
 			<expression>expand Interval[1, 10] per 2</expression>
-			<output>{ 1, 3, 5, 7, 9 }</output>
+			<output>{ Interval[1, 2], Interval[3, 4], Interval[5, 6], Interval[7, 8], Interval[9, 10] }</output>
 		</test>
 	</group>
 	<group name="Contains">

--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -490,9 +490,9 @@
 		</test>
 	</group>
 	<group name="In">
-		<test name="TestInNull">
+		<test name="TestInNullBoundaries">
 			<expression>5 in Interval[null, null]</expression>
-			<output>false</output>
+			<output>true</output>
 		</test>
 		<test name="IntegerIntervalInTrue">
 			<expression>5 in Interval[1, 10]</expression>
@@ -1201,9 +1201,9 @@
 		</test>
 	</group>
 	<group name="ProperlyIncludes">
-		<test name="TestProperlyIncludesNull">
-			<expression>Interval[null, null] properly includes Interval[1, 10]</expression>
-			<output>false</output>
+		<test name="NullBoundariesProperlyIncludesIntegerInterval">
+			<expression>Interval[null as Integer, null as Integer] properly includes Interval[1, 10]</expression>
+			<output>true</output>
 		</test>
 		<test name="IntegerIntervalProperlyIncludesTrue">
 			<expression>Interval[1, 10] properly includes Interval[4, 10]</expression>
@@ -1247,9 +1247,9 @@
 		</test>
 	</group>
 	<group name="ProperlyIncludedIn">
-		<test name="TestProperlyIncludedInNull">
+		<test name="IntegerIntervalProperlyIncludedInNullBoundaries">
 			<expression>Interval[1, 10] properly included in Interval[null, null]</expression>
-			<output>false</output>
+			<output>true</output>
 		</test>
 		<test name="IntegerIntervalProperlyIncludedInTrue">
 			<expression>Interval[4, 10] properly included in Interval[1, 10]</expression>

--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -3,7 +3,7 @@
 	name="CqlIntervalOperatorsTest" reference="https://cql.hl7.org/09-b-cqlreference.html#interval-operators-3">
 	<group name="After">
 		<test name="TestAfterNull">
-			<expression>null after Interval[1, 10]</expression>
+			<expression>(null as Integer) after Interval[1, 10]</expression>
 			<output>null</output>
 		</test>
 		<test name="IntegerIntervalAfterTrue">
@@ -97,7 +97,7 @@
 	</group>
 	<group name="Before">
 		<test name="TestBeforeNull">
-			<expression>null before Interval[1, 10]</expression>
+			<expression>(null as Integer) before Interval[1, 10]</expression>
 			<output>null</output>
 		</test>
 		<test name="IntegerIntervalBeforeFalse">
@@ -251,6 +251,7 @@
 		<test name="ExpandPer1">
 			<expression>expand { Interval[10.0, 12.5] } per 1</expression>
 			<output>{ Interval[10, 10], Interval[11, 11], Interval[12, 12] }</output>
+			<!-- Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Decimal>>,System.Integer). -->
 		</test>
 		<test name="ExpandPerMinute">
 			<expression>expand { Interval[@T10, @T10] } per minute</expression>
@@ -258,7 +259,8 @@
 		</test>
 		<test name="ExpandPer0D1">
 			<expression>expand { Interval[10, 10] } per 0.1</expression>
-			<output>{ Interval[10.0, 10.0], Interval[10.1, 10.1], ..., Interval[10.9, 10.9] }</output>
+			<output>{ Interval[10.0, 10.0], Interval[10.1, 10.1], Interval[10.2, 10.2], Interval[10.3, 10.3], Interval[10.4, 10.4], Interval[10.5, 10.5], Interval[10.6, 10.6], Interval[10.7, 10.7], Interval[10.8, 10.8], Interval[10.9, 10.9] }</output>
+			<!-- Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Integer>>,System.Decimal). -->
 		</test>
 		<test name="ExpandInterval">
 			<expression>expand Interval[1, 10]</expression>

--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -220,11 +220,11 @@
 		</test>
 		<test name="DateTimeCollapse">
 			<expression>collapse { Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)], Interval[DateTime(2012, 1, 10), DateTime(2012, 1, 25)], Interval[DateTime(2012, 5, 10), DateTime(2012, 5, 25)], Interval[DateTime(2012, 5, 20), DateTime(2012, 5, 30)] }</expression>
-			<output>{Interval [ @2012-01-01, @2012-01-25 ], Interval [ @2012-05-10, @2012-05-30 ]}</output>
+			<output>{Interval [ @2012-01-01T, @2012-01-25T ], Interval [ @2012-05-10T, @2012-05-30T ]}</output>
 		</test>
 		<test name="DateTimeCollapse2">
 			<expression>collapse { Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)], Interval[DateTime(2012, 1, 16), DateTime(2012, 5, 25)] }</expression>
-			<output>{Interval [ @2012-01-01, @2012-05-25 ]}</output>
+			<output>{Interval [ @2012-01-01T, @2012-05-25T ]}</output>
 		</test>
 		<test name="TimeCollapse">
 			<expression>collapse { Interval[@T01:59:59.999, @T10:59:59.999], Interval[@T08:59:59.999, @T15:59:59.999], Interval[@T17:59:59.999, @T20:59:59.999], Interval[@T18:59:59.999, @T22:59:59.999] }</expression>
@@ -474,11 +474,11 @@
 		</test>
 		<test name="ExceptDateTimeInterval">
 			<expression>Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)] except Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 15)]</expression>
-			<output>Interval [ @2012-01-05, @2012-01-06 ]</output>
+			<output>Interval [ @2012-01-05T, @2012-01-06T ]</output>
 		</test>
 		<test name="ExceptDateTime2">
 			<expression>Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 16)] except Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 12)]</expression>
-			<output>Interval [ @2012-01-13, @2012-01-16 ]</output>
+			<output>Interval [ @2012-01-13T, @2012-01-16T ]</output>
 		</test>
 		<test name="ExceptTimeInterval">
 			<expression>Interval[@T05:59:59.999, @T10:59:59.999] except Interval[@T08:59:59.999, @T10:59:59.999]</expression>
@@ -695,7 +695,7 @@
 		</test>
 		<test name="DateTimeIntersect">
 			<expression>Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] intersect Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 10)]</expression>
-			<output>Interval [ @2012-01-07, @2012-01-10 ]</output>
+			<output>Interval [ @2012-01-07T, @2012-01-10T ]</output>
 		</test>
 		<test name="TimeIntersect">
 			<expression>Interval[@T04:59:59.999, @T09:59:59.999] intersect Interval[@T04:59:59.999, @T06:59:59.999]</expression>
@@ -1391,7 +1391,7 @@
 		</test>
 		<test name="DateTimeUnion">
 			<expression>Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] union Interval[DateTime(2012, 1, 25), DateTime(2012, 1, 28)]</expression>
-			<output>Interval [ @2012-01-05, @2012-01-28 ]</output>
+			<output>Interval [ @2012-01-05T, @2012-01-28T ]</output>
 		</test>
 		<test name="DateTimeUnionNull">
 			<expression>Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] union Interval[DateTime(2012, 1, 27), DateTime(2012, 1, 28)]</expression>
@@ -1424,12 +1424,10 @@
 			<output>5.0'g'</output>
 		</test>
 		<test name="DateTimeWidth">
-			<expression>width of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]</expression>
-			<output>20 days</output>
+			<expression invalid="true">width of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]</expression>
 		</test>
 		<test name="TimeWidth">
-			<expression>width of Interval[@T05:59:59.999, @T15:59:59.999]</expression>
-			<output>36000000 milliseconds</output>
+			<expression invalid="true">width of Interval[@T05:59:59.999, @T15:59:59.999]</expression>
 		</test>
 	</group>
 	<group name="Interval">

--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -35,12 +35,12 @@
 			<output>{3.8, 2.4, 1.9}</output>
 		</test>
 		<test name="quantityList">
-			<expression>{ 19.99 'lbs', 17.33 'lbs', 10.66 'lbs' }</expression>
-			<output>{19.99 'lbs', 17.33 'lbs', 10.66 'lbs'}</output>
+			<expression>{ 19.99 '[lb_av]', 17.33 '[lb_av]', 10.66 '[lb_av]' }</expression>
+			<output>{19.99 '[lb_av]', 17.33 '[lb_av]', 10.66 '[lb_av]'}</output>
 		</test>
 		<test name="dateTimeList">
 			<expression>{ DateTime(2016), DateTime(2015), DateTime(2010) }</expression>
-			<output>{@2016, @2015, @2010}</output>
+			<output>{@2016T, @2015T, @2010T}</output>
 		</test>
 		<test name="timeList">
 			<expression>{ @T15:59:59.999, @T15:12:59.999, @T15:12:13.999 }</expression>
@@ -95,11 +95,11 @@
 		</test>
 		<test name="DistinctNullNullNull">
 			<expression>distinct { null, null, null}</expression>
-			<output>{}</output>
+			<output>{ null }</output>
 		</test>
 		<test name="DistinctANullANull">
 			<expression>distinct { 'a', null, 'a', null}</expression>
-			<output>{'a'}</output>
+			<output>{'a', null}</output>
 		</test>
 		<test name="Distinct112233">
 			<expression>distinct { 1, 1, 2, 2, 3, 3}</expression>
@@ -174,7 +174,7 @@
 	</group>
 	<group name="Except">
 		<test name="ExceptEmptyListAndEmptyList">
-			<expression>Except({}, {})</expression>
+			<expression>{} except {}</expression>
 			<output>{}</output>
 		</test>
 		<test name="Except1234And23">
@@ -187,7 +187,7 @@
 		</test>
 		<test name="ExceptDateTimeList">
 			<expression>{ DateTime(2012, 5, 10), DateTime(2014, 12, 10), DateTime(2010, 1, 1)} except {DateTime(2014, 12, 10), DateTime(2010, 1, 1) }</expression>
-			<output>{@2012-05-10}</output>
+			<output>{@2012-05-10T}</output>
 		</test>
 		<test name="ExceptTimeList">
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T12:59:59.999 } except { @T20:59:59.999, @T12:59:59.999 }</expression>
@@ -353,7 +353,7 @@
 		</test>
 		<test name="IncludesNullLeft">
 			<expression>null includes {2}</expression>
-			<output>false</output>
+			<output>null</output>
 		</test>
 		<!-- this test is going to the ContainsEvaluator -->
 		<test name="IncludesNullRight">
@@ -405,7 +405,7 @@
 		</test>
 		<test name="IncludedInNullRight">
 			<expression>{'s', 'a', 'm'} included in null</expression>
-			<output>false</output>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="Indexer">
@@ -442,7 +442,7 @@
 	<group name="IndexOf">
 		<test name="IndexOfEmptyNull">
 			<expression>IndexOf({}, null)</expression>
-			<output>-1</output>
+			<output>null</output>
 		</test>
 		<test name="IndexOfNullEmpty">
 			<expression>IndexOf(null, {})</expression>
@@ -450,7 +450,7 @@
 		</test>
 		<test name="IndexOfNullIn1Null">
 			<expression>IndexOf({ 1, null }, null)</expression>
-			<output>1</output>
+			<output>null</output>
 		</test>
 		<test name="IndexOf1In12">
 			<expression>IndexOf({ 1, 2 }, 1)</expression>
@@ -488,7 +488,7 @@
 		</test>
 		<test name="IntersectDateTime">
 			<expression>{ DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) } intersect { DateTime(2012, 5, 10), DateTime(2014, 12, 10), DateTime(2000, 5, 5) }</expression>
-			<output>{@2012-05-10, @2014-12-10}</output>
+			<output>{@2012-05-10T, @2014-12-10T}</output>
 		</test>
 		<test name="IntersectTime">
 			<expression>{ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 } intersect { @T01:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
@@ -547,7 +547,7 @@
 			<output>6</output>
 		</test>
 		<test name="LengthNullList">
-			<expression>Length(null as String)</expression>
+			<expression>Length(null as List&lt;Any&gt;)</expression>
 			<output>0</output>
 		</test>
 	</group>
@@ -585,7 +585,7 @@
 		</test>
 		<test name="EquivalentDateTimeNull">
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} ~ {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10), null}</expression>
-			<output>null</output>
+			<output>false</output>
 		</test>
 		<test name="EquivalentDateTimeFalse">
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} ~ {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 1)}</expression>
@@ -597,7 +597,7 @@
 		</test>
 		<test name="EquivalentTimeNull">
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } ~ { @T15:59:59.999, @T20:59:59.999, null }</expression>
-			<output>null</output>
+			<output>false</output>
 		</test>
 		<test name="EquivalentTimeFalse">
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } ~ { @T15:59:59.999, @T20:59:59.995 }</expression>
@@ -724,7 +724,7 @@
 		</test>
 		<test name="ProperlyIncludesNullLeft">
 			<expression>null properly includes {2}</expression>
-			<output>false</output>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="ProperlyIncludedIn">
@@ -766,7 +766,7 @@
 		</test>
 		<test name="ProperlyIncludedInNulRight">
 			<expression>{'s', 'u', 'n'} properly included in null</expression>
-			<output>false</output>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="SingletonFrom">
@@ -872,7 +872,7 @@
 		</test>
 		<test name="UnionListNullAndListNull">
 			<expression>{ null } union { null }</expression>
-			<output>{null, null}</output>
+			<output>{null}</output>
 		</test>
 		<test name="Union123AndEmpty">
 			<expression>{ 1, 2, 3 } union {}</expression>
@@ -880,7 +880,7 @@
 		</test>
 		<test name="Union123And2">
 			<expression>{ 1, 2, 3 } union { 2 }</expression>
-			<output>{1, 2, 3, 2}</output>
+			<output>{1, 2, 3}</output>
 		</test>
 		<test name="Union123And4">
 			<expression>{ 1, 2, 3 } union { 4 }</expression>
@@ -888,7 +888,7 @@
 		</test>
 		<test name="UnionDateTime">
 			<expression>{ DateTime(2001, 9, 11)} union {DateTime(2012, 5, 10), DateTime(2014, 12, 10) }</expression>
-			<output>{@2001-09-11, @2012-05-10, @2014-12-10}</output>
+			<output>{@2001-09-11T, @2012-05-10T, @2014-12-10T}</output>
 		</test>
 		<test name="UnionTime">
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T12:59:59.999 } union { @T10:59:59.999 }</expression>

--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -26,6 +26,26 @@
 			<expression>({ DateTime(2012, 10, 5, 10), DateTime(2012, 1, 1), DateTime(2012, 1, 1, 12), DateTime(2012, 10, 5) }) S sort desc</expression>
 			<output>{DateTime(2012, 10, 5, 10), DateTime(2012, 10, 5), DateTime(2012, 1, 1, 12), DateTime(2012, 1, 1)}</output>
 		</test>
+		<test name="intList">
+			<expression>{ 3, 2, 1 }</expression>
+			<output>{3, 2, 1}</output>
+		</test>
+		<test name="decimalList">
+			<expression>{ 3.8, 2.4, 1.9 }</expression>
+			<output>{3.8, 2.4, 1.9}</output>
+		</test>
+		<test name="quantityList">
+			<expression>{ 19.99 'lbs', 17.33 'lbs', 10.66 'lbs' }</expression>
+			<output>{19.99 'lbs', 17.33 'lbs', 10.66 'lbs'}</output>
+		</test>
+		<test name="dateTimeList">
+			<expression>{ DateTime(2016), DateTime(2015), DateTime(2010) }</expression>
+			<output>{@2016, @2015, @2010}</output>
+		</test>
+		<test name="timeList">
+			<expression>{ @T15:59:59.999, @T15:12:59.999, @T15:12:13.999 }</expression>
+			<output>{@T15:59:59.999, @T15:12:59.999, @T15:12:13.999}</output>
+		</test>
 	</group>
 	<group name="Contains">
 		<test name="ContainsABNullHasNull">
@@ -112,11 +132,11 @@
 			<output>null</output>
 		</test>
 		<test name="EqualEmptyListNull">
-			<expression>{} = null</expression>
+			<expression>{} as List&lt;String&gt; = null</expression>
 			<output>null</output>
 		</test>
 		<test name="EqualNullEmptyList">
-			<expression>null = {}</expression>
+			<expression>null = {} as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 		<test name="EqualEmptyListAndEmptyList">
@@ -873,28 +893,6 @@
 		<test name="UnionTime">
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T12:59:59.999 } union { @T10:59:59.999 }</expression>
 			<output>{@T15:59:59.999, @T20:59:59.999, @T12:59:59.999, @T10:59:59.999}</output>
-		</test>
-	</group>
-	<group name="Sort">
-		<test name="intList">
-			<expression>{ 3, 2, 1 }</expression>
-			<output>{3, 2, 1}</output>
-		</test>
-		<test name="decimalList">
-			<expression>{ 3.8, 2.4, 1.9 }</expression>
-			<output>{3.8, 2.4, 1.9}</output>
-		</test>
-		<test name="quantityList">
-			<expression>{ 19.99 'lbs', 17.33 'lbs', 10.66 'lbs' }</expression>
-			<output>{19.99 'lbs', 17.33 'lbs', 10.66 'lbs'}</output>
-		</test>
-		<test name="dateTimeList">
-			<expression>{ DateTime(2016), DateTime(2015), DateTime(2010) }</expression>
-			<output>{@2016, @2015, @2010}</output>
-		</test>
-		<test name="timeList">
-			<expression>{ @T15:59:59.999, @T15:12:59.999, @T15:12:13.999 }</expression>
-			<output>{@T15:59:59.999, @T15:12:59.999, @T15:12:13.999}</output>
 		</test>
 	</group>
 </tests>

--- a/tests/cql/CqlStringOperatorsTest.xml
+++ b/tests/cql/CqlStringOperatorsTest.xml
@@ -224,7 +224,7 @@
 			<output>'Who put the bang in the bang she bang she bang?'</output>
 		</test>
 		<test name="ReplaceMatchesSpaces">
-			<expression>ReplaceMatches('All that glitters is not gold', '\\s', '\\$')</expression>
+			<expression>ReplaceMatches('All that glitters is not gold', '\\s', '$$')</expression>
 			<output>'All$that$glitters$is$not$gold'</output>
 		</test>
 	</group>

--- a/tests/cql/CqlStringOperatorsTest.xml
+++ b/tests/cql/CqlStringOperatorsTest.xml
@@ -8,7 +8,7 @@
 		</test>
 		<test name="CombineEmptyList">
 			<expression>Combine({})</expression>
-			<output>''</output>
+			<output>null</output>
 		</test>
 		<test name="CombineABC">
 			<expression>Combine({'a', 'b', 'c'})</expression>
@@ -112,7 +112,7 @@
 	<group name="Length">
 		<test name="LengthNullString">
 			<expression>Length(null as String)</expression>
-			<output>0</output>
+			<output>null</output>
 			<!-- cast is required due to ambiguity with Length(String) and Length(List&lt;Any&gt;) -->
 		</test>
 		<test name="LengthEmptyString">
@@ -339,7 +339,7 @@
 	<group name="toString tests">
 		<test name="QuantityToString">
 			<expression>ToString(125 'cm')</expression>
-			<output>'125cm'</output>
+			<output>'125 \'cm\''</output>
 		</test>
 		<test name="DateTimeToString1">
 			<expression>ToString(DateTime(2000, 1, 1))</expression>
@@ -351,7 +351,7 @@
 		</test>
 		<test name="DateTimeToString3">
 			<expression>ToString(DateTime(2000, 1, 1, 8, 25, 25, 300, -7))</expression>
-			<output>'2000-01-01T08:25:25.300'</output>
+			<output>'2000-01-01T08:25:25.300-07:00'</output>
 		</test>
 		<test name="TimeToString1">
 			<expression>ToString(@T09:30:01.003)</expression>

--- a/tests/cql/CqlTypeOperatorsTest.xml
+++ b/tests/cql/CqlTypeOperatorsTest.xml
@@ -12,7 +12,7 @@
 		</test>
 		<test name="AsDateTime">
 			<expression>DateTime(2014, 01, 01) as DateTime</expression>
-			<output>@2014-01-01</output>
+			<output>@2014-01-01T</output>
 		</test>
 	</group>
 	<group name="Convert">
@@ -30,7 +30,7 @@
 		</test>
 		<test name="StringToDateTime">
 			<expression>convert '2014-01-01' to DateTime</expression>
-			<output>@2014-01-01</output>
+			<output>@2014-01-01T</output>
 		</test>
 		<test name="StringToTime">
 			<expression>convert 'T14:30:00.0' to Time</expression>
@@ -70,7 +70,7 @@
 	<group name="ToDateTime">
 		<test name="ToDateTime1">
 			<expression>ToDateTime('2014-01-01')</expression>
-			<output>@2014-01-01</output>
+			<output>@2014-01-01T</output>
 		</test>
 		<test name="ToDateTime2">
 			<expression>ToDateTime('2014-01-01T12:05')</expression>
@@ -82,15 +82,15 @@
 		</test>
 		<test name="ToDateTime4">
 			<expression>ToDateTime('2014-01-01T12:05:05.955+01:30')</expression>
-			<output>@2014-01-01T12:05:05.955</output>
+			<output>@2014-01-01T12:05:05.955+01:30</output>
 		</test>
 		<test name="ToDateTime5">
 			<expression>ToDateTime('2014-01-01T12:05:05.955-01:15')</expression>
-			<output>@2014-01-01T12:05:05.955</output>
+			<output>@2014-01-01T12:05:05.955-01:15</output>
 		</test>
 		<test name="ToDateTime6">
 			<expression>ToDateTime('2014-01-01T12:05:05.955Z')</expression>
-			<output>@2014-01-01T12:05:05.955</output>
+			<output>@2014-01-01T12:05:05.955+00:00</output>
 		</test>
 		<test name="ToDateTimeMalformed">
 			<expression invalid="true">ToDateTime('2014/01/01T12:05:05.955Z')</expression>
@@ -111,7 +111,7 @@
 	</group>
 	<group name="ToQuantity">
 		<test name="String5D5CMToQuantity">
-			<expression>ToQuantity('5.5 cm')</expression>
+			<expression>ToQuantity('5.5 \'cm\'')</expression>
 			<output>5.5'cm'</output>
 		</test>
 	</group>
@@ -126,7 +126,7 @@
 		</test>
 		<test name="Quantity5D5CMToString">
 			<expression>ToString(5.5 'cm')</expression>
-			<output>'5.5cm'</output>
+			<output>'5.5 \'cm\''</output>
 		</test>
 		<test name="BooleanTrueToString">
 			<expression>ToString(true)</expression>

--- a/tests/cql/CqlTypesTest.xml
+++ b/tests/cql/CqlTypesTest.xml
@@ -20,7 +20,7 @@
 		</test>
 		<test name="AnyDateTime">
 			<expression>DateTime(2012, 4, 4)</expression>
-			<output>@2012-04-04</output>
+			<output>@2012-04-04T</output>
 		</test>
 		<test name="AnyTime">
 			<expression>@T09:00:00.000</expression>
@@ -74,11 +74,11 @@
 		</test>
 		<test name="DateTimeIncomplete">
 			<expression>DateTime(2015, 2, 10)</expression>
-			<output>@2015-02-10</output>
+			<output>@2015-02-10T</output>
 		</test>
 		<test name="DateTimeUncertain">
 			<expression>days between DateTime(2015, 2, 10) and DateTime(2015, 3)</expression>
-			<output>Interval [ 19, 49 ]</output>
+			<output>Interval [ 18, 49 ]</output>
 			<!-- TODO: How to handle the fact the question is resulting in an
 			undertainty interval and that CQL/ELM seem to provide no direct way of
 			selecting the same value, conceptually an implementation internal;
@@ -131,12 +131,12 @@
 	</group>
 	<group name="Quantity">
 		<test name="QuantityTest">
-			<expression>150.2 'lbs'</expression>
-			<output>150.2 'lbs'</output>
+			<expression>150.2 '[lb_av]'</expression>
+			<output>150.2 '[lb_av]'</output>
 		</test>
 		<test name="QuantityTest2">
-			<expression>2.5589 'eskimo kisses'</expression>
-			<output>2.5589 'eskimo kisses'</output>
+			<expression>2.5589 '{eskimo kisses}'</expression>
+			<output>2.5589 '{eskimo kisses}'</output>
 		</test>
 		<test name="QuantityFractionalTooBig">
 			<expression>5.999999999 'g'</expression>

--- a/tests/cql/CqlTypesTest.xml
+++ b/tests/cql/CqlTypesTest.xml
@@ -156,15 +156,15 @@
 	<group name="Time">
 		<test name="TimeUpperBoundHours">
 			<expression invalid="true">@T24:59:59.999</expression>
-			<!-- Invalid date-time input (T24:59:59.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm). -->
+			<!-- Translation Error: Invalid date-time input (T24:59:59.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm). -->
 		</test>
 		<test name="TimeUpperBoundMinutes">
 			<expression invalid="true">@T23:60:59.999</expression>
-			<!-- Invalid date-time input (T23:60:59.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm). -->
+			<!-- Translation Error: Invalid date-time input (T23:60:59.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm). -->
 		</test>
 		<test name="TimeUpperBoundSeconds">
 			<expression invalid="true">@T23:59:60.999</expression>
-			<!--Invalid date-time input (T23:59:60.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm).  -->
+			<!--Translation Error: Invalid date-time input (T23:59:60.999). Use ISO 8601 date time representation (yyyy-MM-ddThh:mm:ss.mmmmZhh:mm).  -->
 		</test>
 		<test name="TimeUpperBoundMillis">
 			<expression invalid="true">@T23:59:59.10000</expression>


### PR DESCRIPTION
This PR provides minor fixes for issues I encountered while trying to implement these tests in the JavaScript CQL engine.  Since the JS engine cannot compile CQL to ELM, our approach is to compile all the test CQL snippets to ELM at build time (instead of at test time) -- so we then run the tests off pre-compiled ELM.

As a result of this process, we found several tests that contain CQL that does not cleanly compile to elm.  This PR fixes what is fixable and adds comments for those tests that we're immediately fixable (or for which I was not sure what the right fix should be).