### PR TITLE
Remove Redundant Closing Group Tag

### DIFF
--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -274,7 +274,6 @@
 			<output>@T10:30:00.000</output>
 		</test>
 	</group>
-	</group>
 	<group name="Ln">
 		<test name="LnNull">
 			<expression>Ln(null)</expression>


### PR DESCRIPTION
I noticed that, because the file was just not parseable.