### PR TITLE
Fix Typo on Long Info

### DIFF
--- a/spec/09-b-cqlreference.adoc
+++ b/spec/09-b-cqlreference.adoc
@@ -206,7 +206,7 @@ CQL supports positive and negative decimal values with a _precision_ (meaning to
 
 [.note-info]
 ____
-The CodeSystem type is a new feature being introduced in CQL 1.5, and has trial-use status.
+The Long type is a new feature being introduced in CQL 1.5, and has trial-use status.
 ____
 
 *Definition:*


### PR DESCRIPTION
Is Long even trial-use in 1.5.1?