### PR TITLE
Fix typo in text

### DIFF
--- a/spec/09-b-cqlreference.adoc
+++ b/spec/09-b-cqlreference.adoc
@@ -201,7 +201,7 @@ ____
 
 The [.id]#Decimal# type represents real values within CQL.
 
-CQL supports positive and negative decimal values with a _precision_ (meaning total number of possible digits) of 28 and a _scale_ (meaning number of possible digits to the right of the decimal) of 8. In other words, decimal values in the range (-10^28^ + 1)/10^8^ to (10^28^-1)/10^-8^ with a step size of 10^-8^.
+CQL supports positive and negative decimal values with a _precision_ (meaning total number of possible digits) of 28 and a _scale_ (meaning number of possible digits to the right of the decimal) of 8. In other words, decimal values in the range (-10^28^ + 1)/10^8^ to (10^28^-1)/10^8^ with a step size of 10^-8^.
 
 
 [[long-1]]


### PR DESCRIPTION
This fixes the typo in the decimal value range and makes it consistent with https://github.com/HL7/cql/blob/3553f6faee383ff4457a8a3e676449602a4fef52/spec/09-b-cqlreference.adoc?plain=1#L2419 and https://github.com/HL7/cql/blob/3553f6faee383ff4457a8a3e676449602a4fef52/spec/03-developersguide.adoc?plain=1#L675.