### PR TITLE
Edge cases in ProperContains and ProperIn documentation

### DIFF
--- a/spec/09-b-cqlreference.adoc
+++ b/spec/09-b-cqlreference.adoc
@@ -5498,9 +5498,9 @@ The following examples illustrate the behavior of the [.kw]#properly includes# o
 [source,cql]
 ----
 define "ProperlyIncludesIsTrue": { 1, 3, 5, 7 } properly includes { 1, 3, 5 }
-define "ProperlyIncludesIsAlsoTrue": { 1, 3, 5, null } properly includes null
+define "ProperlyIncludesIsNull": { 1, 3, 5, null } properly includes null
 define "ProperlyIncludesIsFalse": { 1, 3, 5 } properly includes { 1, 3, 5 }
-define "ProperlyIncludesIsAlsoFalse": null properly includes { 1, 3, 5 }
+define "ProperlyIncludesIsAlsoNull": null properly includes { 1, 3, 5 }
 ----
 
 [[properly-included-in-1]]
@@ -5531,9 +5531,9 @@ The following examples illustrate the behavior of the [.kw]#properly included in
 [source,cql]
 ----
 define "ProperlyIncludedInIsTrue": { 1, 3, 5 } properly included in { 1, 3, 5, 7 }
-define "ProperlyIncludedInIsAlsoTrue": null properly included in { 1, 3, 5 }
+define "ProperlyIncludedInIsNull": null properly included in { 1, 3, 5 }
 define "ProperlyIncludedInIsFalse": { 1, 3, 5 } properly included in { 1, 3, 5 }
-define "ProperlyIncludedInIsAlsoFalse": { 1, 3, 5, null } properly included in null
+define "ProperlyIncludedInIsAlsoNull": { 1, 3, 5, null } properly included in null
 ----
 
 [[singleton-from]]

--- a/spec/09-b-cqlreference.adoc
+++ b/spec/09-b-cqlreference.adoc
@@ -5510,7 +5510,8 @@ define "ProperlyIncludesIsAlsoFalse": null properly includes { 1, 3, 5 }
 
 [source,cql]
 ----
-properly included in(left List<T>, right list<T>) Boolean
+properly included in(left List<T>, right List<T>) Boolean
+properly included in(left T, right List<T>) Boolean
 ----
 
 *Description:*

--- a/spec/elm/schema/expression.xsd
+++ b/spec/elm/schema/expression.xsd
@@ -2350,9 +2350,11 @@ There are two overloads of this operator:
 	List, T: The type of T must be the same as the element type of the list.
 	Interval, T : The type of T must be the same as the point type of the interval.
 
-For the List, T overload, this operator returns true if the given element is in the list, and it is not the only element in the list, using equality semantics, with the exception that null elements are considered equal. If the first argument is null, the result is false. If the second argument is null, the result is true if the list contains any null elements and at least one other element, and false otherwise.
+For the List, T overload, this operator returns true if the given element is in the list, and it is not the only element in the list, using equality semantics, with the exception that null elements are considered equal.
 
-For the Interval, T overload, this operator returns true if the given point is greater than the starting point of the interval, and less than the ending point of the interval, as determined by the Start and End operators.  If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation are performed at the specified precision. If the first argument is null, the result is false. If the second argument is null, the result is null.</xs:documentation>
+For the Interval, T overload, this operator returns true if the given point is greater than the starting point of the interval, and less than the ending point of the interval, as determined by the Start and End operators.  If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation are performed at the specified precision.
+
+If either argument is null, the result is null.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="BinaryExpression">
@@ -2388,9 +2390,11 @@ There are two overloads of this operator:
 	T, List : The type of T must be the same as the element type of the list.
 	T, Interval : The type of T must be the same as the point type of the interval.
 
-For the T, List overload, this operator returns if the given element is in the given list, and it is not the only element in the list, using equality semantics, with the exception that null elements are considered equal. If the first argument is null, the result is true if the list contains any null elements, and at least one other element, and false otherwise. If the second argument is null, the result is false.
+For the T, List overload, this operator returns if the given element is in the given list, and it is not the only element in the list, using equality semantics, with the exception that null elements are considered equal.
 
-For the T, Interval overload, this operator returns true if the given point is greater than the starting point, and less than the ending point of the interval, as determined by the Start and End operators. If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation are performed at the specified precision. If the first argument is null, the result is null. If the second argument is null the result is false.</xs:documentation>
+For the T, Interval overload, this operator returns true if the given point is greater than the starting point, and less than the ending point of the interval, as determined by the Start and End operators. If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation are performed at the specified precision.
+
+If either argument is null, the result is null.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="BinaryExpression">


### PR DESCRIPTION
This fixes the content of expression.xsd for ELM's `ProperContains` and `ProperIn` to make it consistent with the CQL reference.

In particular:

* `ProperIn(T, List<T>)` is equivalent to the `T properly included in List<T>` CQL expression and `ProperIn(T, Interval<T>)` is equivalent to `T properly included in Interval<T>`. The CQL reference states that if either argument is null, the result is null ([link for List](https://github.com/HL7/cql/blob/v1.5.2/spec/09-b-cqlreference.adoc?plain=1#L5524), [link for Interval](https://github.com/HL7/cql/blob/v1.5.2/spec/09-b-cqlreference.adoc?plain=1#L4737)), which is now consistent with the annotation for `ProperIn` in expression.xsd.
* `ProperContains(List<T>, T)` is equivalent to the `List<T> properly includes T` CQL expression and `ProperContains(Interval<T>, T)` is equivalent to `Interval<T> properly includes T`. The CQL reference states that if either argument is null, the result is null ([link for List](https://github.com/HL7/cql/blob/v1.5.2/spec/09-b-cqlreference.adoc?plain=1#L5492), [link for Interval](https://github.com/HL7/cql/blob/v1.5.2/spec/09-b-cqlreference.adoc?plain=1#L4705)), which is now consistent with the annotation for `ProperContains` in expression.xsd.

Also fixed the examples illustrating these edge cases.