### PR TITLE
FHIR-52782: Library block should come first

### DIFF
--- a/input/images/cql/cql.g4
+++ b/input/images/cql/cql.g4
@@ -11,6 +11,15 @@ import fhirpath;
  * Parser Rules
  */
 
+library
+    :
+    directive*
+    libraryDefinition?
+    definition*
+    statement*
+    EOF
+    ;
+
 directive
     : '#' identifier (':' STRING)?
     ;
@@ -23,15 +32,6 @@ definition
     | codeDefinition
     | conceptDefinition
     | parameterDefinition
-    ;
-
-library
-    :
-    directive*
-    libraryDefinition?
-    definition*
-    statement*
-    EOF
     ;
 
 /*


### PR DESCRIPTION
The `library` block is moved up to make it a start rule.