### PR TITLE
FHIR-52780: Fix contextRelationship rule

### DIFF
--- a/input/images/cql/cql.g4
+++ b/input/images/cql/cql.g4
@@ -211,7 +211,7 @@ typeInfo
     ;
 
 contextRelationship
-    : 'related' 'to' qualifiedIdentifier 'context' 'by' '{' identifier (',' identifier)* '}'
+    : 'related' 'to' qualifiedIdentifier 'by' '{' identifier (',' identifier)* '}'
     ;
 
 conversionInfoDefinition


### PR DESCRIPTION
Adjusts the `contextRelationship` rule in the grammar to make it compatible with the context definition examples like:

```
define type Observation extends DomainResource {
  subject Patient,
  code CodeableConcept,
  value Choice<CodeableConcept, Quantity>
}
related to Patient by { subject }
```
